### PR TITLE
Alternative approach for ArrayColumn operations

### DIFF
--- a/src/main/scala/habla/doric/syntax/ArrayColumnOps.scala
+++ b/src/main/scala/habla/doric/syntax/ArrayColumnOps.scala
@@ -6,72 +6,54 @@ import cats.data.{Kleisli, NonEmptyChain}
 import cats.implicits._
 
 import org.apache.spark.sql.{Column, DataFrame, functions => f}
-import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions._, LambdaFunction.{identity => id}
 
 trait ArrayColumnOps {
 
-  type DoricEither[A] = Either[NonEmptyChain[Throwable], A]
-
-  private val toValidated = new FunctionK[DoricEither, DoricValidated] {
-    override def apply[A](fa: DoricEither[A]): DoricValidated[A] = fa.toValidated
-  }
-  private val toEither = new FunctionK[DoricValidated, DoricEither] {
-    override def apply[A](fa: DoricValidated[A]): DoricEither[A] = fa.toEither
-  }
-
   implicit class ArrayColumnSyntax[T](private val col: ArrayColumn[T]) {
 
-    def getIndex(n: Int): DoricColumn[T] = {
+    def getIndex(n: Int): DoricColumn[T] =
       col.elem.map(_.apply(n)).toDC
-    }
 
-    private val xarg = UnresolvedNamedLambdaVariable(Seq("x"))
-    private val yarg = UnresolvedNamedLambdaVariable(Seq("y"))
-
-    def transform[A](f: DoricColumn[T] => DoricColumn[A]): DoricColumn[Array[A]] =
-      (col.elem, f(DoricColumn[T](new Column(xarg))).elem).mapN { (arr, fun) =>
-        new Column(ArrayTransform(arr.expr, LambdaFunction(fun.expr, Seq(xarg))))
+    def transform[A](fun: DoricColumn[T] => DoricColumn[A]): DoricColumn[Array[A]] =
+      (col.elem, fun(x).elem).mapN { (a, f) =>
+        new Column(ArrayTransform(a.expr, lam1(f.expr)))
       }.toDC
 
     def transformWithIndex[A](
-        f: (DoricColumn[T], IntegerColumn) => DoricColumn[A]): DoricColumn[Array[A]] =
-      (col.elem, f(
-          DoricColumn[T](new Column(xarg)),
-          DoricColumn[Int](new Column(yarg))).elem).mapN { (arr, fun) =>
-        new Column(ArrayTransform(arr.expr, LambdaFunction(fun.expr, Seq(xarg, yarg))))
+        fun: (DoricColumn[T], IntegerColumn) => DoricColumn[A]): DoricColumn[Array[A]] =
+      (col.elem, fun(x, y).elem).mapN { (a, f) =>
+        new Column(ArrayTransform(a.expr, lam2(f.expr)))
       }.toDC
 
     def aggregate[A, B](
-        initialValue: DoricColumn[A],
+        zero: DoricColumn[A],
         merge: (DoricColumn[A], DoricColumn[T]) => DoricColumn[A],
         finish: DoricColumn[A] => DoricColumn[B]): DoricColumn[B] =
-      (col.elem,
-       initialValue.elem,
-       merge(DoricColumn[A](new Column(xarg)), DoricColumn[T](new Column(yarg))).elem,
-       finish(DoricColumn[A](new Column(xarg))).elem).mapN { (arr, init, mrg, fin) =>
-        new Column(ArrayAggregate(
-          arr.expr,
-          init.expr,
-          LambdaFunction(mrg.expr, Seq(xarg, yarg)),
-          LambdaFunction(fin.expr, Seq(xarg))))
+      (col.elem, zero.elem, merge(x, y).elem, finish(x).elem).mapN { (a, z, m, f) =>
+        new Column(ArrayAggregate(a.expr, z.expr, lam2(m.expr), lam1(f.expr)))
       }.toDC
 
-    def aggregate[A](initialValue: DoricColumn[A])(
+    def aggregate[A](
+        zero: DoricColumn[A])(
         merge: (DoricColumn[A], DoricColumn[T]) => DoricColumn[A]): DoricColumn[A] =
-      (col.elem, initialValue.elem, merge(
-          DoricColumn[A](new Column(xarg)),
-          DoricColumn[T](new Column(yarg))).elem).mapN { (arr, init, fun) =>
-        new Column(ArrayAggregate(
-          arr.expr,
-          init.expr,
-          LambdaFunction(fun.expr, Seq(xarg, yarg)),
-          LambdaFunction.identity))
+      (col.elem, zero.elem, merge(x, y).elem).mapN { (a, z, m) =>
+        new Column(ArrayAggregate(a.expr, z.expr, lam2(m.expr), id))
       }.toDC
 
-    def filter(f: DoricColumn[T] => BooleanColumn): DoricColumn[Array[T]] =
-      (col.elem, f(DoricColumn[T](new Column(xarg))).elem).mapN { (arr, fun) =>
-        new Column(ArrayFilter(arr.expr, LambdaFunction(fun.expr, Seq(xarg))))
+    def filter(p: DoricColumn[T] => BooleanColumn): DoricColumn[Array[T]] =
+      (col.elem, p(x).elem).mapN { (a, f) =>
+        new Column(ArrayFilter(a.expr, lam1(f.expr)))
       }.toDC
+
+    private def x[A] = DoricColumn[A](new Column(xarg))
+    private def y[A] = DoricColumn[A](new Column(yarg))
+
+    private def lam1(e: Expression) = LambdaFunction(e, Seq(xarg))
+    private def lam2(e: Expression) = LambdaFunction(e, Seq(xarg, yarg))
+
+    private val xarg = UnresolvedNamedLambdaVariable(Seq("x"))
+    private val yarg = UnresolvedNamedLambdaVariable(Seq("y"))
   }
 }
 

--- a/src/main/scala/habla/doric/syntax/ArrayColumnOps.scala
+++ b/src/main/scala/habla/doric/syntax/ArrayColumnOps.scala
@@ -20,68 +20,58 @@ trait ArrayColumnOps {
   }
 
   implicit class ArrayColumnSyntax[T](private val col: ArrayColumn[T]) {
+
     def getIndex(n: Int): DoricColumn[T] = {
       col.elem.map(_.apply(n)).toDC
     }
 
     private val xarg = UnresolvedNamedLambdaVariable(Seq("x"))
+    private val yarg = UnresolvedNamedLambdaVariable(Seq("y"))
 
     def transform[A](f: DoricColumn[T] => DoricColumn[A]): DoricColumn[Array[A]] =
       (col.elem, f(DoricColumn[T](new Column(xarg))).elem).mapN { (arr, fun) =>
         new Column(ArrayTransform(arr.expr, LambdaFunction(fun.expr, Seq(xarg))))
       }.toDC
 
-    private def doricFunc[A, B](f: DoricColumn[A] => DoricColumn[B]): Doric[Column => Column] = {
-      val x = UnresolvedNamedLambdaVariable(Seq("x"))
-      f(DoricColumn[A](new Column(x))).elem
-        .mapK(toEither)
-        .flatMap(_ =>
-          Kleisli[DoricEither, DataFrame, Column => Column](df =>
-            ((x: Column) => f(DoricColumn[A](x)).elem.run(df).toEither.right.get).asRight
-          )
-        )
-        .mapK(toValidated)
-    }
-
-    private def doricFunc2[A1, A2, B](
-        f: (DoricColumn[A1], DoricColumn[A2]) => DoricColumn[B]
-    ): Doric[(Column, Column) => Column] = {
-      val x = UnresolvedNamedLambdaVariable(Seq("x"))
-      val y = UnresolvedNamedLambdaVariable(Seq("y"))
-      f(DoricColumn[A1](new Column(x)), DoricColumn[A2](new Column(y))).elem
-        .mapK(toEither)
-        .flatMap(_ =>
-          Kleisli[DoricEither, DataFrame, (Column, Column) => Column](df =>
-            (
-                (
-                    x: Column,
-                    y: Column
-                ) => f(DoricColumn[A1](x), DoricColumn[A2](y)).elem.run(df).toEither.right.get
-            ).asRight
-          )
-        )
-        .mapK(toValidated)
-    }
-
     def transformWithIndex[A](
-        func: (DoricColumn[T], IntegerColumn) => DoricColumn[A]
-    ): DoricColumn[Array[A]] =
-      (col.elem, doricFunc2(func)).mapN((c, untypedFunc) => f.transform(c, untypedFunc)).toDC
+        f: (DoricColumn[T], IntegerColumn) => DoricColumn[A]): DoricColumn[Array[A]] =
+      (col.elem, f(
+          DoricColumn[T](new Column(xarg)),
+          DoricColumn[Int](new Column(yarg))).elem).mapN { (arr, fun) =>
+        new Column(ArrayTransform(arr.expr, LambdaFunction(fun.expr, Seq(xarg, yarg))))
+      }.toDC
 
     def aggregate[A, B](
         initialValue: DoricColumn[A],
         merge: (DoricColumn[A], DoricColumn[T]) => DoricColumn[A],
-        finish: DoricColumn[A] => DoricColumn[B]
-    ): DoricColumn[B] =
-      (col.elem, initialValue.elem, doricFunc2(merge), doricFunc(finish)).mapN(f.aggregate).toDC
+        finish: DoricColumn[A] => DoricColumn[B]): DoricColumn[B] =
+      (col.elem,
+       initialValue.elem,
+       merge(DoricColumn[A](new Column(xarg)), DoricColumn[T](new Column(yarg))).elem,
+       finish(DoricColumn[A](new Column(xarg))).elem).mapN { (arr, init, mrg, fin) =>
+        new Column(ArrayAggregate(
+          arr.expr,
+          init.expr,
+          LambdaFunction(mrg.expr, Seq(xarg, yarg)),
+          LambdaFunction(fin.expr, Seq(xarg))))
+      }.toDC
 
     def aggregate[A](initialValue: DoricColumn[A])(
-        merge: (DoricColumn[A], DoricColumn[T]) => DoricColumn[A]
-    ): DoricColumn[A] =
-      (col.elem, initialValue.elem, doricFunc2(merge)).mapN(f.aggregate).toDC
+        merge: (DoricColumn[A], DoricColumn[T]) => DoricColumn[A]): DoricColumn[A] =
+      (col.elem, initialValue.elem, merge(
+          DoricColumn[A](new Column(xarg)),
+          DoricColumn[T](new Column(yarg))).elem).mapN { (arr, init, fun) =>
+        new Column(ArrayAggregate(
+          arr.expr,
+          init.expr,
+          LambdaFunction(fun.expr, Seq(xarg, yarg)),
+          LambdaFunction.identity))
+      }.toDC
 
-    def filter(func: DoricColumn[T] => BooleanColumn): DoricColumn[Array[T]] =
-      (col.elem, doricFunc(func)).mapN((c, funt) => f.filter(c, funt)).toDC
+    def filter(f: DoricColumn[T] => BooleanColumn): DoricColumn[Array[T]] =
+      (col.elem, f(DoricColumn[T](new Column(xarg))).elem).mapN { (arr, fun) =>
+        new Column(ArrayFilter(arr.expr, LambdaFunction(fun.expr, Seq(xarg))))
+      }.toDC
   }
-
 }
+


### PR DESCRIPTION
This contribution supplies an alternative approach to deal with array-based operations, namely:
* `transform`
* `transformWithIndex`
* `aggregate`
* `filter`

Essentially, we exploit the expression API to get safer and more concise implementations.

Since this is my very first contribution to *doric*, supplying this link is a must (I'm sorry): https://www.youtube.com/watch?v=Y18jIMMNoHA