### PR TITLE
ci: add worflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,13 @@
 name: CI
 on:
-  push:
-    branches-ignore:
-      - main
-      - gh-pages
   pull_request:
     branches-ignore:
       - gh-pages
+  workflow_dispatch:
 
 jobs:
   build:
+    #if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publishTempSite.yml
+++ b/.github/workflows/publishTempSite.yml
@@ -1,9 +1,9 @@
 name: Publish temp site
 on:
   push:
-    branches-ignore:
-      - main
-      - gh-pages
+    branches:
+      - '*doc/*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publishTempSite.yml
+++ b/.github/workflows/publishTempSite.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    if: github.GITHUB_REPOSITORY != 'hablapps/doric'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
After merging this PR:
1. affected worfklows will be available to be triggered manually at any branch
2. only `doc` branches will publish at gh-pages