### PR TITLE
ci: release executed only if habla repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
 name: Release
+
 on:
   push:
     branches: [main]
     tags: ["*"]
+
 jobs:
   publish:
+    if: github.GITHUB_REPOSITORY == 'hablapps/doric'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Release workflow will execute anyway, but the `publish` step will not execute