### PR TITLE
fix: [~] str interpolator now prints empty if null column (issue #191)

### DIFF
--- a/core/src/main/scala/doric/syntax/Interpolators.scala
+++ b/core/src/main/scala/doric/syntax/Interpolators.scala
@@ -4,15 +4,15 @@ package syntax
 trait Interpolators {
   implicit class doricStringInterpolator(val sc: StringContext) {
     def ds(columns: StringColumn*): StringColumn = {
-      val literals: Seq[DoricColumn[String]] = sc.parts.map(_.lit)
+      val literals: Seq[StringColumn] = sc.parts.map(_.lit)
 
-      val cols: Seq[DoricColumn[String]] = literals
+      val cols: Seq[StringColumn] = literals
         .zipAll(columns, "".lit, "".lit)
         .flatMap { case (a, b) =>
           List(a, b)
         }
 
-      concat(cols: _*)
+      concatWs("".lit, cols: _*)
     }
   }
 }

--- a/core/src/test/scala/doric/syntax/InterpolatorsSpec.scala
+++ b/core/src/test/scala/doric/syntax/InterpolatorsSpec.scala
@@ -1,10 +1,9 @@
 package doric
 package syntax
 
+import org.apache.spark.sql.{functions => f}
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
-
-import org.apache.spark.sql.{functions => f}
 
 class InterpolatorsSpec
     extends DoricTestElements
@@ -31,6 +30,20 @@ class InterpolatorsSpec
         List(
           Some("Column has value: -->value 1"),
           Some("Column has value: -->value 2")
+        )
+      )
+    }
+
+    it("should work if null columns") {
+      val dfNull = List("value 1", null)
+        .toDF(colName)
+      dfNull.testColumns2(colName, "Column has value:")(
+        (c, str) => ds"${str.lit} -->${colString(c)}",
+        (c, str) =>
+          f.concat(f.lit(str), f.lit(" -->"), f.coalesce(f.col(c), f.lit(""))),
+        List(
+          Some("Column has value: -->value 1"),
+          Some("Column has value: -->")
         )
       )
     }


### PR DESCRIPTION
<!------------------------------------------------------------------->
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please, label your PR correctly as a fix, enhancement, etc.  -->
<!------------------------------------------------------------------->

## Description
<!-------------------------------------->
<!--- Describe your changes in detail -->
<!-------------------------------------->
Using `concat_ws` instead of `concat` we can avoid this error (but we have as limitation that nulls will be skipped)

## Related Issue
<!---------------------------------------------------------------------------------------->
<!--- This project only accepts pull requests related to open issues                    -->
<!--- If suggesting a new feature or change, please discuss it in an issue first        -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce   -->
<!--- Write "Resolves #XXXX" in your comment to auto-close the issue that your PR fixes -->
<!---------------------------------------------------------------------------------------->
Resolves #191 

## How Has This Been Tested?
<!---------------------------------------------------------------------------->
<!--- Please describe in detail how you tested your changes.                -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc.             -->
<!---------------------------------------------------------------------------->
- [x] This pull request contains appropriate tests?
