### PR TITLE
Delete unused dependencies to be able to port doric to scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,8 +100,6 @@ lazy val core = project
       "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided", // scala-steward:off
       "org.typelevel"       %% "cats-core"        % "2.7.0",
       "com.lihaoyi"         %% "sourcecode"       % "0.2.8",
-      "io.monix"            %% "newtypes-core"    % "0.2.1",
-      "com.github.mrpowers" %% "spark-daria"      % "1.2.3"  % "test",
       "com.github.mrpowers" %% "spark-fast-tests" % "1.2.0"  % "test",
       "org.scalatest"       %% "scalatest"        % "3.2.11" % "test"
     ),

--- a/core/src/main/scala/doric/CName.scala
+++ b/core/src/main/scala/doric/CName.scala
@@ -1,9 +1,10 @@
 package doric
 
 import doric.types.SparkType
-import monix.newtypes.NewtypeWrapped
 
-object CName extends NewtypeWrapped[String] {
+case class CName(value: String)
+
+object CName {
   implicit def columnByName[T: SparkType](colName: CName): NamedDoricColumn[T] =
     col(colName.value)
 }

--- a/core/src/main/scala/doric/doric.scala
+++ b/core/src/main/scala/doric/doric.scala
@@ -13,8 +13,6 @@ package object doric extends syntax.All with sem.All {
   type Doric[T]          = Kleisli[DoricValidated, Dataset[_], T]
   type DoricJoin[T]      = Kleisli[DoricValidated, (Dataset[_], Dataset[_]), T]
 
-  type CName = CName.Type
-
   object Doric {
 
     def apply[T](a: T): Doric[T] =


### PR DESCRIPTION
Delete unused dependencies to be able to port doric to scala 2.11

## Description
Deleted unused spark daria, and newtype that it doesn't have a 2.11 version
## Related Issue
#205 

## Motivation and Context
Make possible to build doric for scala 2.11

## How Has This Been Tested?
Against latest version of spark and waiting for the CI flow
- [x] This pull request contains appropriate tests?
