### PR TITLE
ci: [~] delete PRs and forms checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -9,14 +9,24 @@ body:
 #    attributes:
 #      value: |
 #        Thanks for your contribution!
-  - type: checkboxes
+# - type: checkboxes
+#   id: issue_not_duplicated
+#   attributes:
+#     label: Issue duplicity
+#     description: Please, before creating a new issue, check if there is another one like this one.
+#     options:
+#       - label: I have checked the current created issues, and it seems there is no other issue like this one.
+#         required: true
+  - type: dropdown
     id: issue_not_duplicated
     attributes:
       label: Issue duplicity
       description: Please, before creating a new issue, check if there is another one like this one.
       options:
-        - label: I have checked the current created issues and it seems there is no other issue like this one.
-          required: true
+        - NO
+        - YES
+    validations:
+      required: true
   - type: input
     id: version
     attributes:
@@ -28,7 +38,7 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: Please, tell us what happend and how this affects to your use case.
+      description: Please, tell us what happened and how this affects to your use case.
       placeholder: What happened?
       value: "Boom! Big reveal! I turned myself into a pickle!"
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -15,7 +15,8 @@ assignees: ''
 <!-- Please, before creating a new issue, check if there is -->
 <!-- another one like this one                              -->
 <!------------------------------------------------------------>
-- [ ] I have checked the current created issues and it seems there is no other issue like this one
+- I have checked the current created issues, and it seems there is no other issue like this one:
+  - YES / NO
 
 ## Doric version *
 <!------------------------------------------->

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -9,14 +9,24 @@ body:
 #    attributes:
 #      value: |
 #        Thanks for contributing!
-  - type: checkboxes
+# - type: checkboxes
+#   id: feature_request_not_duplicated
+#   attributes:
+#     label: Feature request duplicity
+#     description: Please, check there is no other feature request like this one to avoid duplicates.
+#     options:
+#       - label: It seems this feature is not requested yet
+#         required: true
+  - type: dropdown
     id: feature_request_not_duplicated
     attributes:
       label: Feature request duplicity
       description: Please, check there is no other feature request like this one to avoid duplicates.
       options:
-        - label: It seems this feature is not requested yet
-          required: true
+        - NO
+        - YES
+    validations:
+      required: true
   - type: textarea
     id: suggestion
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -12,7 +12,8 @@ assignees: ''
 <!------------------------------------------------------------------->
 
 Please, check there is no other feature request like this one to avoid duplicates: [see doric issues](https://github.com/hablapps/doric/issues)
-- [ ] It seems this feature is not requested yet
+- It seems this feature is not requested yet:
+  - YES / NO
 
 ## Expected Behavior
 <!--------------------------------->


### PR DESCRIPTION
Current forms and templates contains a checkbox. This very checkbox translates as an issue/PR task and it is not