### PR TITLE
Empty arrays returns the expected datatype

### DIFF
--- a/core/src/test/scala/doric/syntax/ArrayColumnsSpec.scala
+++ b/core/src/test/scala/doric/syntax/ArrayColumnsSpec.scala
@@ -2,6 +2,7 @@ package doric
 package syntax
 
 import doric.sem.{ChildColumnNotFound, ColumnTypeError, DoricMultiError, SparkErrorWrapper}
+import doric.types.SparkType
 
 import org.apache.spark.sql.{Row, functions => f}
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
@@ -299,6 +300,20 @@ class ArrayColumnsSpec extends DoricTestElements {
         (c1, c2) => f.array(f.col(c1), f.col(c2)),
         List(Some(Array("a", "b")))
       )
+    }
+
+    it("should work be of the expected type when is empty") {
+      val df = spark
+        .range(5)
+        .select(
+          array[Long]().as("l"),
+          array[String]().as("s"),
+          array[(String, String)]().as("r")
+        )
+
+      df("l").expr.dataType === SparkType[Array[Long]].dataType
+      df("s").expr.dataType === SparkType[Array[String]].dataType
+      df("r").expr.dataType === SparkType[Array[(String, String)]].dataType
     }
   }
 


### PR DESCRIPTION
## Description
Empty arrays contains a inner datatype of null instead of the type provided in doric, this can create inconsistencies checking the typing and not be what is expected.

## Related Issue and dependencies

* Resolves #273 

## How Has This Been Tested?
Tests to check the type when the array is empty

- This pull request contains appropriate tests?:
  - YES
