### PR TITLE
Custom aggregation with doric syntax

### DIFF
--- a/core/src/main/scala/doric/doric.scala
+++ b/core/src/main/scala/doric/doric.scala
@@ -27,6 +27,11 @@ package object doric extends syntax.All with sem.All {
       Kleisli[DoricValidated, Dataset[_], T] { _ =>
         a.valid
       }
+
+    def apply[T](f: Dataset[_] => T): Doric[T] =
+      Kleisli[DoricValidated, Dataset[_], T] { df =>
+        f(df).valid
+      }
   }
 
   private[doric] type DoricEither[A] = EitherNec[DoricSingleError, A]

--- a/core/src/main/scala/doric/syntax/AggregationColumns.scala
+++ b/core/src/main/scala/doric/syntax/AggregationColumns.scala
@@ -3,6 +3,7 @@ package syntax
 
 import cats.implicits._
 import doric.types.NumericType
+import doric.Doric
 
 import org.apache.spark.sql.{Column, functions => f}
 import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
@@ -381,4 +382,5 @@ private[syntax] trait AggregationColumns {
     */
   def groupingId(colName: CName, colNames: CName*): LongColumn =
     Doric(f.grouping_id(colName.value, colNames.map(_.value): _*)).toDC
+
 }

--- a/core/src/main/spark_3.2_3.3/scala/doric/sqlExpressions/CustomAgg.scala
+++ b/core/src/main/spark_3.2_3.3/scala/doric/sqlExpressions/CustomAgg.scala
@@ -1,0 +1,36 @@
+package doric.sqlExpressions
+
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.DeclarativeAggregate
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.types.DataType
+
+case class CustomAgg(
+    child: Expression,
+    initialValue: Expression,
+    update: (Expression, Expression) => Expression,
+    merge: (Expression, Expression) => Expression,
+    evaluate: Expression => Expression
+) extends DeclarativeAggregate
+    with UnaryLike[Expression] {
+
+  private final val accum =
+    AttributeReference("accum", initialValue.dataType)()
+
+  override val initialValues: Seq[Expression]     = Seq(initialValue)
+  override val updateExpressions: Seq[Expression] = Seq(update(accum, child))
+  override val mergeExpressions: Seq[Expression] = Seq(
+    merge(accum.left, accum.right)
+  )
+  override val evaluateExpression: Expression = evaluate(accum)
+
+  override protected def withNewChildInternal(
+      newChild: Expression
+  ): Expression = copy(child = newChild)
+
+  override lazy val nullable: Boolean = child.nullable
+
+  override lazy val dataType: DataType = evaluate(accum).dataType
+
+  override def aggBufferAttributes: Seq[AttributeReference] = Seq(accum)
+}

--- a/core/src/main/spark_3.2_3.3/scala/doric/syntax/AggregationColumns32.scala
+++ b/core/src/main/spark_3.2_3.3/scala/doric/syntax/AggregationColumns32.scala
@@ -1,0 +1,66 @@
+package doric
+package syntax
+
+import cats.implicits._
+import doric.sqlExpressions.CustomAgg
+import doric.types.SparkType
+
+import org.apache.spark.sql.{Column, Dataset}
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+trait AggregationColumns32 {
+  def customAgg[T, A: SparkType, E](
+      column: DoricColumn[T],
+      initial: DoricColumn[A],
+      update: (DoricColumn[A], DoricColumn[T]) => DoricColumn[A],
+      merge: (DoricColumn[A], DoricColumn[A]) => DoricColumn[A],
+      evaluate: DoricColumn[A] => DoricColumn[E]
+  ): DoricColumn[E] = {
+    val updateExpr: Doric[(Expression, Expression) => Expression] =
+      Doric((df: Dataset[_]) =>
+        (e1: Expression, e2: Expression) =>
+          update(Doric(new Column(e1)).toDC, Doric(new Column(e2)).toDC).elem
+            .run(df)
+            .map(_.expr)
+            .getOrElse(null)
+      )
+    val mergeExpr = Doric((df: Dataset[_]) =>
+      (e1: Expression, e2: Expression) =>
+        merge(Doric(new Column(e1)).toDC, Doric(new Column(e2)).toDC).elem
+          .run(df.sparkSession.emptyDataFrame)
+          .map(_.expr)
+          .getOrElse(null)
+    )
+    val evaluateExpr = Doric((df: Dataset[_]) =>
+      (e1: Expression) =>
+        evaluate(Doric(new Column(e1)).toDC).elem
+          .run(df.sparkSession.emptyDataFrame)
+          .map(_.expr)
+          .getOrElse(null)
+    )
+    (
+      column.elem,
+      initial.elem,
+      updateExpr,
+      mergeExpr,
+      evaluateExpr,
+      update(initial, column).elem,
+      merge(initial, initial).elem.lmap[Dataset[_]](df =>
+        df.sparkSession.emptyDataFrame
+      ),
+      evaluate(initial).elem.lmap[Dataset[_]](df =>
+        df.sparkSession.emptyDataFrame
+      )
+    ).mapN { (c, i, u, m, e, _, _, _) =>
+      new Column(
+        CustomAgg(
+          c.expr,
+          i.expr,
+          u,
+          m,
+          e
+        ).toAggregateExpression(isDistinct = false)
+      )
+    }.toDC
+  }
+}

--- a/core/src/main/spark_3.2_mount/scala/doric/syntax/All.scala
+++ b/core/src/main/spark_3.2_mount/scala/doric/syntax/All.scala
@@ -27,3 +27,4 @@ private[doric] trait All
     with CommonColumns3x
     with MapColumns3x
     with StringColumn3x
+    with AggregationColumns32

--- a/core/src/main/spark_3.3_mount/scala/doric/syntax/All.scala
+++ b/core/src/main/spark_3.3_mount/scala/doric/syntax/All.scala
@@ -27,3 +27,4 @@ private[doric] trait All
     with CommonColumns3x
     with MapColumns3x
     with StringColumn3x
+    with AggregationColumns32

--- a/core/src/test/spark_3.2_3.3/scala/doric/syntax/AggregationColumns32Spec.scala
+++ b/core/src/test/spark_3.2_3.3/scala/doric/syntax/AggregationColumns32Spec.scala
@@ -1,0 +1,157 @@
+package doric
+package syntax
+
+import doric.DoricTestElements
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.sql.{Column, Row}
+
+class AggregationColumns32Spec
+    extends DoricTestElements
+    with EitherValues
+    with Matchers {
+
+  describe("custom aggregations") {
+
+    it("should work") {
+      spark
+        .range(10000)
+        .withColumn("id", 1L.lit)
+        .select(
+          customAgg[Long, Long, Long](
+            col[Long]("id"),
+            0L.lit,
+            (x, y) => x + y,
+            (x, y) => x + y + 100L.lit,
+            identity
+          ).as("result")
+        )
+        .collectCols(col[Long]("result"))
+        .head shouldBe 10100
+
+      spark
+        .range(10)
+        .withColumn("id", array(col[Long]("id")))
+        .select(
+          customAgg[Array[Long], Array[Long], Array[Long]](
+            col("id"), // a column of arrays of Long
+            array(),   // init value for the update
+            // merge and make distinct in same task
+            (x, y) => concatArrays(x, y).distinct,
+            // merge results after the shuffle
+            (x, y) => concatArrays(x, y).distinct,
+            // return the array with distinct values
+            identity
+          ).as("result")
+        )
+        .collectCols(col[Array[Long]]("result"))
+        .head shouldBe Array
+        .range(0, 10)
+        .map(_.toLong)
+
+      spark
+        .range(100)
+        .select(
+          customAgg[Long, Array[Long], Array[Long]](
+            col("id"),
+            array(),
+            (a, b) => a.union(array(b)).sort(false.lit),
+            _ union _,
+            identity
+          )
+        )
+    }
+
+    it("should detect if we reference a column in a invalid method") {
+
+      val df = spark
+        .range(10000)
+
+      val errorReference1 = customAgg[Long, Long, Long](
+        col[Long]("id"),
+        0.toLong.lit,
+        (x, y) => x + y,
+        (x, y) => x + y + 100L.lit + col("id"),
+        x => x
+      )
+
+      val errors1: DoricValidated[Column] = errorReference1.elem.run(df)
+      errors1 shouldBe 'invalid
+      val unwrapedErrors1 = errors1.toEither.left.value
+      unwrapedErrors1.length shouldBe 1
+
+      val errorReference2 = customAgg[Long, Long, Long](
+        col[Long]("id"),
+        0.toLong.lit,
+        (x, y) => x + y,
+        (x, y) => x + y + 100L.lit,
+        x => x + col("id")
+      )
+
+      val errors2: DoricValidated[Column] = errorReference2.elem.run(df)
+      errors2 shouldBe 'invalid
+      val unwrapedErrors2 = errors2.toEither.left.value
+      unwrapedErrors2.length shouldBe 1
+
+      val errorReference3 = customAgg[Long, Long, Long](
+        col[Long]("id"),
+        0.toLong.lit,
+        (x, y) => x + y,
+        (x, y) => x + y + 100L.lit + col("id"),
+        x => x + col("id")
+      )
+
+      val errors3: DoricValidated[Column] = errorReference3.elem.run(df)
+      errors3 shouldBe 'invalid
+      val unwrapedErrors3 = errors3.toEither.left.value
+      unwrapedErrors3.length shouldBe 2
+    }
+
+    it("should accept middle values as structs") {
+
+      val df = spark
+        .range(5)
+
+      val complexAggWithNames = customAgg[Long, Row, Double](
+        col[Long]("id"),
+        struct(lit(0L).as("_1"), lit(0L).as("_2")),
+        (x, y) =>
+          struct(
+            x.getChild[Long]("_1") + y,
+            x.getChild[Long]("_2") + 1L.lit
+          ),
+        (x, y) =>
+          struct(
+            x.getChild[Long]("_1") + y.getChild[Long]("_1"),
+            x.getChild[Long]("_2") + y.getChild[Long]("_2")
+          ),
+        x => x.getChild[Long]("_1") / x.getChild[Long]("_2")
+      )
+
+      noException shouldBe thrownBy {
+        df.select(complexAggWithNames)
+      }
+
+      val complexAggWithoutNames = customAgg[Long, Row, Double](
+        col[Long]("id"),
+        struct(lit(0L), lit(0L)),
+        (x, y) =>
+          struct(
+            x.getChild[Long]("col1") + y,
+            x.getChild[Long]("col2") + 1L.lit
+          ),
+        (x, y) =>
+          struct(
+            x.getChild[Long]("col1") + y.getChild[Long]("col1"),
+            x.getChild[Long]("col2") + y.getChild[Long]("col2")
+          ),
+        x => x.getChild[Long]("col1") / x.getChild[Long]("col2")
+      )
+
+      noException shouldBe thrownBy {
+        df.select(complexAggWithoutNames)
+      }
+    }
+  }
+}

--- a/core/src/test/spark_3.2_3.3/scala/doric/syntax/AggregationColumns32Spec.scala
+++ b/core/src/test/spark_3.2_3.3/scala/doric/syntax/AggregationColumns32Spec.scala
@@ -77,7 +77,7 @@ class AggregationColumns32Spec
       )
 
       val errors1: DoricValidated[Column] = errorReference1.elem.run(df)
-      errors1 shouldBe 'invalid
+      errors1.isInvalid shouldBe true
       val unwrapedErrors1 = errors1.toEither.left.value
       unwrapedErrors1.length shouldBe 1
 
@@ -90,7 +90,7 @@ class AggregationColumns32Spec
       )
 
       val errors2: DoricValidated[Column] = errorReference2.elem.run(df)
-      errors2 shouldBe 'invalid
+      errors2.isInvalid shouldBe true
       val unwrapedErrors2 = errors2.toEither.left.value
       unwrapedErrors2.length shouldBe 1
 
@@ -103,7 +103,7 @@ class AggregationColumns32Spec
       )
 
       val errors3: DoricValidated[Column] = errorReference3.elem.run(df)
-      errors3 shouldBe 'invalid
+      errors3.isInvalid shouldBe true
       val unwrapedErrors3 = errors3.toEither.left.value
       unwrapedErrors3.length shouldBe 2
     }

--- a/docs/docs/_data/navigation.yml
+++ b/docs/docs/_data/navigation.yml
@@ -14,7 +14,8 @@ docs:
         url: /docs/errors/
       - title: "Modularity"
         url: /docs/modularity/
-
+      - title: "Doric exclusive features"
+        url: /docs/doric-exclusive-featues/
 main:
   - title: "Documentation"
     url: /docs/

--- a/docs/docs/docs/exclusive.md
+++ b/docs/docs/docs/exclusive.md
@@ -1,0 +1,53 @@
+---
+title: Doric Documentation
+permalink: docs/doric-exclusive-featues/
+---
+
+```scala mdoc:invisible
+import org.apache.spark.sql.{functions => f}
+
+val spark = doric.DocInit.getSpark
+import spark.implicits._
+
+import doric._
+import doric.implicitConversions._
+import doric.AggExample.customMean
+```
+
+## Aggregations with doric syntax
+Doric introduces a simpler way to implement user defined aggregations, using doric's own syntax.
+The creation needs only five elements:
+- The column to make the aggregation
+- zero: the initialization of the value on each task.
+- Update: the function to update the accumulated value when processing a new column value.
+- Merge: a function to compare the results of all the Update results, two by two
+- The final transformation of the value once all merges are applied.
+
+The following example shows how to implement the average of a column of type int
+
+```scala
+      val customMean = customAgg[Long, Row, Double](
+        col[Long]("id"), // The column to work on
+        struct(lit(0L), lit(0L)), // setting the sum and the count to 0
+        (x, y) =>
+          struct(
+            x.getChild[Long]("col1") + y, // adding the value to the sum
+            x.getChild[Long]("col2") + 1L.lit // increasing in 1 the count of elemnts
+          ),
+        (x, y) =>
+          struct(
+            x.getChild[Long]("col1") + y.getChild[Long]("col1"), // obtaining the total sum of all 
+            x.getChild[Long]("col2") + y.getChild[Long]("col2") // obtaining the total count of all
+          ),
+        x => x.getChild[Long]("col1") / x.getChild[Long]("col2") // the total sum divided by the count
+      )
+```
+
+Now you can use your new aggregation as usual
+
+```scala mdoc
+spark.range(10).show()
+
+spark.range(10).select(customMean.as("customMean")).show()
+```
+

--- a/docs/src/main/scala/doric/AggExample.scala
+++ b/docs/src/main/scala/doric/AggExample.scala
@@ -1,0 +1,29 @@
+package doric
+
+import org.apache.spark.sql.Row
+object AggExample {
+  val customMean: DoricColumn[Double] = customAgg[Long, Row, Double](
+    col[Long]("id"),          // The column to work on
+    struct(lit(0L), lit(0L)), // setting the sum and the count to 0
+    (x, y) =>
+      struct(
+        x.getChild[Long]("col1") + y, // adding the value to the sum
+        x.getChild[Long](
+          "col2"
+        ) + 1L.lit // increasing in 1 the count of elemnts
+      ),
+    (x, y) =>
+      struct(
+        x.getChild[Long]("col1") + y.getChild[Long](
+          "col1"
+        ), // obtaining the total sum of all
+        x.getChild[Long]("col2") + y.getChild[Long](
+          "col2"
+        ) // obtaining the total count of all
+      ),
+    x =>
+      x.getChild[Long]("col1").cast[Double] / x
+        .getChild[Long]("col2")
+        .cast[Double] // the total sum divided by the count
+  )
+}


### PR DESCRIPTION
## Description
This pull request allows the creation of aggregation functions with the syntax of doric.

Example of mean implemented with `customAgg` in doric
 ```scala
 val complexAggWithoutNames = customAgg[Long, Row, Double](
        col[Long]("id"),
        struct(lit(0L), lit(0L)),
        (x, y) =>
          struct(
            x.getChild[Long]("col1") + y,
            x.getChild[Long]("col2") + 1L.lit
          ),
        (x, y) =>
          struct(
            x.getChild[Long]("col1") + y.getChild[Long]("col1"),
            x.getChild[Long]("col2") + y.getChild[Long]("col2")
          ),
        x => x.getChild[Long]("col1") / x.getChild[Long]("col2")
      )
```

## Related Issues and dependencies

* Resolves #311 
* Depends on XXX

## How Has This Been Tested?
The test is developed with simple and complex zero values.

- This pull request contains the appropriate tests?:
  - YES
