### PR TITLE
feat: [+] MatchBuilder column fun & AND/OR aggregate functions

### DIFF
--- a/core/src/main/scala/doric/syntax/AggregationColumns.scala
+++ b/core/src/main/scala/doric/syntax/AggregationColumns.scala
@@ -251,21 +251,7 @@ private[syntax] trait AggregationColumns {
     *
     * @group Aggregation Boolean Type
     */
-  def &&(col: BooleanColumn): BooleanColumn = andAgg(col)
-
-  /**
-    * Aggregate function: returns the AND value for a boolean column
-    *
-    * @group Aggregation Boolean Type
-    */
   def andAgg(col: BooleanColumn): BooleanColumn = min(col)
-
-  /**
-    * Aggregate function: returns the OR value for a boolean column
-    *
-    * @group Aggregation Boolean Type
-    */
-  def ||(col: BooleanColumn): BooleanColumn = orAgg(col)
 
   /**
     * Aggregate function: returns the OR value for a boolean column

--- a/core/src/main/scala/doric/syntax/AggregationColumns.scala
+++ b/core/src/main/scala/doric/syntax/AggregationColumns.scala
@@ -247,6 +247,34 @@ private[syntax] trait AggregationColumns {
     col.elem.map(f.min).toDC
 
   /**
+    * Aggregate function: returns the AND value for a boolean column
+    *
+    * @group Aggregation Boolean Type
+    */
+  def &&(col: BooleanColumn): BooleanColumn = andAgg(col)
+
+  /**
+    * Aggregate function: returns the AND value for a boolean column
+    *
+    * @group Aggregation Boolean Type
+    */
+  def andAgg(col: BooleanColumn): BooleanColumn = min(col)
+
+  /**
+    * Aggregate function: returns the OR value for a boolean column
+    *
+    * @group Aggregation Boolean Type
+    */
+  def ||(col: BooleanColumn): BooleanColumn = orAgg(col)
+
+  /**
+    * Aggregate function: returns the OR value for a boolean column
+    *
+    * @group Aggregation Boolean Type
+    */
+  def orAgg(col: BooleanColumn): BooleanColumn = max(col)
+
+  /**
     * Aggregate function: returns the maximum value of the expression in a group.
     *
     * @group Aggregation Any Type

--- a/core/src/main/scala/doric/syntax/ControlStructures.scala
+++ b/core/src/main/scala/doric/syntax/ControlStructures.scala
@@ -1,6 +1,8 @@
 package doric
 package syntax
 
+import doric.types.SparkType
+
 private[syntax] trait ControlStructures {
 
   /**
@@ -12,4 +14,8 @@ private[syntax] trait ControlStructures {
     *   WhenBuilder instance to add the required logic.
     */
   def when[T]: WhenBuilder[T] = WhenBuilder()
+
+  implicit class ControlStructuresImpl[O: SparkType](col: DoricColumn[O]) {
+    def matches[T]: MatchBuilderInit[O, T] = MatchBuilderInit(col)
+  }
 }

--- a/core/src/main/scala/doric/syntax/ControlStructures.scala
+++ b/core/src/main/scala/doric/syntax/ControlStructures.scala
@@ -16,6 +16,6 @@ private[syntax] trait ControlStructures {
   def when[T]: WhenBuilder[T] = WhenBuilder()
 
   implicit class ControlStructuresImpl[O: SparkType](col: DoricColumn[O]) {
-    def matches[T]: MatchBuilderInit[O, T] = MatchBuilderInit(col)
+    def matches[T]: MatchBuilder[O, T] = MatchBuilder(col, WhenBuilder())
   }
 }

--- a/core/src/main/scala/doric/syntax/WhenBuilder.scala
+++ b/core/src/main/scala/doric/syntax/WhenBuilder.scala
@@ -63,44 +63,6 @@ final private[doric] case class WhenBuilder[T](
 
 }
 
-final protected case class MatchBuilderInit[O: SparkType, T](
-    private val dCol: DoricColumn[O]
-) {
-
-  /**
-    * ads the first case comparing the given column with the affected column
-    *
-    * @param equality
-    * the given column to compare
-    * @param elem
-    * the returned element if the condition is true
-    * @return
-    * new instance of the builder with the previous cases added
-    */
-  def caseW(
-      equality: DoricColumn[O],
-      elem: DoricColumn[T]
-  ): MatchBuilder[O, T] =
-    MatchBuilder(dCol, when[T].caseW(dCol === equality, elem))
-
-  /**
-    * ads the first case using a function to compare the given column and the affected column
-    *
-    * @param function
-    * BooleanColumn with the condition to satisfy
-    * @param elem
-    * the returned element if the condition is true
-    * @return
-    * new instance of the builder with the previous cases added
-    */
-  def caseW(
-      function: DoricColumn[O] => BooleanColumn,
-      elem: DoricColumn[T]
-  ): MatchBuilder[O, T] =
-    MatchBuilder(dCol, when[T].caseW(function(dCol), elem))
-
-}
-
 final protected case class MatchBuilder[O: SparkType, T](
     private val dCol: DoricColumn[O],
     private val cases: WhenBuilder[T]

--- a/core/src/test/scala/doric/TypedColumnTest.scala
+++ b/core/src/test/scala/doric/TypedColumnTest.scala
@@ -212,6 +212,7 @@ trait TypedColumnTest extends Matchers with DatasetComparer {
           aggSparkCol.asDoric[T].as(sparkCol)
         )
         .selectCName(doricCol, sparkCol)
+        .orderBy(keyCol.value)
 
       compareDifferences(result, expected)
     }

--- a/core/src/test/scala/doric/control/WhenBuilderSpec.scala
+++ b/core/src/test/scala/doric/control/WhenBuilderSpec.scala
@@ -76,10 +76,6 @@ class WhenBuilderSpec
     import spark.implicits._
     val matchResult = "matchResult"
 
-    it("won't let an otherwise be set if no cases") {
-      "colInt(\"c1\").matches[String].otherwiseNull" shouldNot compile
-    }
-
     it("transform a column given an equality or a function (otherwiseNull)") {
 
       val myCol = colInt("c1")

--- a/core/src/test/scala/doric/syntax/AggregationColumnsSpec.scala
+++ b/core/src/test/scala/doric/syntax/AggregationColumnsSpec.scala
@@ -28,7 +28,7 @@ class AggregationColumnsSpec
         "keyCol",
         sum(colInt("col1")),
         f.sum("col1"),
-        List(Some(3L), Some(6L))
+        List(Some(6L), Some(3L))
       )
     }
 
@@ -43,7 +43,7 @@ class AggregationColumnsSpec
         "keyCol",
         sum(colFloat("col1")),
         f.sum("col1"),
-        List(Some(3.0d), Some(6.5d))
+        List(Some(6.5d), Some(3.0d))
       )
     }
   }
@@ -62,7 +62,7 @@ class AggregationColumnsSpec
         "keyCol",
         count(colInt("col1")),
         f.count(f.col("col1")),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
 
@@ -77,7 +77,7 @@ class AggregationColumnsSpec
         "keyCol",
         count("col1"),
         f.count("col1"),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
   }
@@ -96,7 +96,7 @@ class AggregationColumnsSpec
         "keyCol",
         first(colInt("col1")),
         f.first(f.col("col1")),
-        List(Some(3), Some(1))
+        List(Some(1), Some(3))
       )
     }
 
@@ -111,7 +111,7 @@ class AggregationColumnsSpec
         "keyCol",
         first(colInt("col1"), ignoreNulls = true),
         f.first(f.col("col1"), ignoreNulls = true),
-        List(Some(3), Some(5))
+        List(Some(5), Some(3))
       )
     }
 
@@ -126,7 +126,7 @@ class AggregationColumnsSpec
         "keyCol",
         first(colInt("col1"), ignoreNulls = false),
         f.first(f.col("col1"), ignoreNulls = false),
-        List(Some(3), None)
+        List(None, Some(3))
       )
     }
   }
@@ -145,7 +145,7 @@ class AggregationColumnsSpec
         "keyCol",
         last(colInt("col1")),
         f.last(f.col("col1")),
-        List(Some(3), Some(5))
+        List(Some(5), Some(3))
       )
     }
 
@@ -160,7 +160,7 @@ class AggregationColumnsSpec
         "keyCol",
         last(colInt("col1"), ignoreNulls = true),
         f.last(f.col("col1"), ignoreNulls = true),
-        List(Some(3), Some(1))
+        List(Some(1), Some(3))
       )
     }
 
@@ -175,7 +175,7 @@ class AggregationColumnsSpec
         "keyCol",
         last(colInt("col1"), ignoreNulls = false),
         f.last(f.col("col1"), ignoreNulls = false),
-        List(Some(3), None)
+        List(None, Some(3))
       )
     }
   }
@@ -194,7 +194,7 @@ class AggregationColumnsSpec
         "keyCol",
         aproxCountDistinct("col1"),
         f.approx_count_distinct("col1"),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
 
@@ -211,7 +211,7 @@ class AggregationColumnsSpec
         "keyCol",
         aproxCountDistinct("col1", 0.05),
         f.approx_count_distinct("col1", 0.05),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
 
@@ -226,7 +226,7 @@ class AggregationColumnsSpec
         "keyCol",
         aproxCountDistinct(colInt("col1")),
         f.approx_count_distinct(f.col("col1")),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
 
@@ -243,7 +243,7 @@ class AggregationColumnsSpec
         "keyCol",
         aproxCountDistinct(colInt("col1"), 0.05),
         f.approx_count_distinct(f.col("col1"), 0.05),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
   }
@@ -281,7 +281,7 @@ class AggregationColumnsSpec
         "keyCol",
         collectList(colInt("col1")),
         f.collect_list(f.col("col1")),
-        List(Some(Array(3)), Some(Array(1, 5)))
+        List(Some(Array(1, 5)), Some(Array(3)))
       )
     }
   }
@@ -301,7 +301,7 @@ class AggregationColumnsSpec
         "keyCol",
         collectSet(colInt("col1")),
         f.collect_set(f.col("col1")),
-        List(Some(Array(3)), Some(Array(1, 5)))
+        List(Some(Array(1, 5)), Some(Array(3)))
       )
     }
   }
@@ -341,7 +341,7 @@ class AggregationColumnsSpec
         "keyCol",
         countDistinct(colDouble("col1"), colString("col2")),
         f.countDistinct(f.col("col1"), f.col("col2")),
-        List(Some(1L), Some(3L))
+        List(Some(3L), Some(1L))
       )
     }
 
@@ -356,7 +356,7 @@ class AggregationColumnsSpec
         "keyCol",
         countDistinct("col1", "col2"),
         f.countDistinct("col1", "col2"),
-        List(Some(1L), Some(2L))
+        List(Some(2L), Some(1L))
       )
     }
   }
@@ -375,7 +375,7 @@ class AggregationColumnsSpec
         "keyCol",
         covarPop(colDouble("col1"), colDouble("col2")),
         f.covar_pop(f.col("col1"), f.col("col2")),
-        List(Some(0.0), Some(0.25))
+        List(Some(0.25), Some(0.0))
       )
     }
   }
@@ -394,7 +394,7 @@ class AggregationColumnsSpec
         "keyCol",
         covarSamp(colDouble("col1"), colDouble("col2")),
         f.covar_samp(f.col("col1"), f.col("col2")),
-        List(None, Some(0.5))
+        List(Some(0.5), None)
       )
     }
   }
@@ -413,7 +413,7 @@ class AggregationColumnsSpec
         "keyCol",
         kurtosis(colDouble("col1")),
         f.kurtosis(f.col("col1")),
-        List(None, Some(-2.0))
+        List(Some(-2.0), None)
       )
     }
   }
@@ -432,7 +432,7 @@ class AggregationColumnsSpec
         "keyCol",
         max(colDouble("col1")),
         f.max(f.col("col1")),
-        List(Some(6.0), Some(4.0))
+        List(Some(4.0), Some(6.0))
       )
     }
   }
@@ -451,7 +451,75 @@ class AggregationColumnsSpec
         "keyCol",
         min(colDouble("col1")),
         f.min(f.col("col1")),
-        List(Some(6.0), Some(3.0))
+        List(Some(3.0), Some(6.0))
+      )
+    }
+  }
+
+  describe("and doric function") {
+    import spark.implicits._
+
+    it("should get the `and` aggregation") {
+      val df = List(
+        ("k1", true),
+        ("k1", false),
+        ("k2", true)
+      ).toDF("keyCol", "col1")
+
+      df.testAggregation(
+        "keyCol",
+        andAgg(colBoolean("col1")),
+        f.min(f.col("col1")),
+        List(Some(false), Some(true))
+      )
+    }
+
+    it("should work with `&&`") {
+      val df = List(
+        ("k1", true),
+        ("k1", false),
+        ("k2", true)
+      ).toDF("keyCol", "col1")
+
+      df.testAggregation(
+        "keyCol",
+        &&(colBoolean("col1")),
+        f.min(f.col("col1")),
+        List(Some(false), Some(true))
+      )
+    }
+  }
+
+  describe("or doric function") {
+    import spark.implicits._
+
+    it("should get the `or` aggregation") {
+      val df = List(
+        ("k1", true),
+        ("k1", false),
+        ("k2", false)
+      ).toDF("keyCol", "col1")
+
+      df.testAggregation(
+        "keyCol",
+        orAgg(colBoolean("col1")),
+        f.max(f.col("col1")),
+        List(Some(true), Some(false))
+      )
+    }
+
+    it("should work with `||`") {
+      val df = List(
+        ("k1", true),
+        ("k1", false),
+        ("k2", false)
+      ).toDF("keyCol", "col1")
+
+      df.testAggregation(
+        "keyCol",
+        ||(colBoolean("col1")),
+        f.max(f.col("col1")),
+        List(Some(true), Some(false))
       )
     }
   }
@@ -470,7 +538,7 @@ class AggregationColumnsSpec
         "keyCol",
         mean(colDouble("col1")),
         f.mean(f.col("col1")),
-        List(Some(6.0), Some(3.5))
+        List(Some(3.5), Some(6.0))
       )
     }
   }
@@ -491,7 +559,7 @@ class AggregationColumnsSpec
         "keyCol",
         skewness(colDouble("col1")),
         f.skewness(f.col("col1")),
-        List(None, Some(1.1135657469022011))
+        List(Some(1.1135657469022011), None)
       )
     }
   }
@@ -511,7 +579,7 @@ class AggregationColumnsSpec
         "keyCol",
         stdDev(colDouble("col1")),
         f.stddev(f.col("col1")),
-        List(None, Some(1.0))
+        List(Some(1.0), None)
       )
     }
 
@@ -527,7 +595,7 @@ class AggregationColumnsSpec
         "keyCol",
         stdDevSamp(colDouble("col1")),
         f.stddev_samp(f.col("col1")),
-        List(None, Some(1.0))
+        List(Some(1.0), None)
       )
     }
   }
@@ -547,7 +615,7 @@ class AggregationColumnsSpec
         "keyCol",
         stdDevPop(colDouble("col1")),
         f.stddev_pop(f.col("col1")),
-        List(Some(0.0), Some(0.816496580927726))
+        List(Some(0.816496580927726), Some(0.0))
       )
     }
   }
@@ -569,7 +637,7 @@ class AggregationColumnsSpec
         new Column(
           Sum(f.col("col1").expr).toAggregateExpression(isDistinct = true)
         ),
-        List(Some(6L), Some(4L))
+        List(Some(4L), Some(6L))
       )
     }
 
@@ -587,7 +655,7 @@ class AggregationColumnsSpec
         new Column(
           Sum(f.col("col1").expr).toAggregateExpression(isDistinct = true)
         ),
-        List(Some(6.0), Some(4.0))
+        List(Some(4.0), Some(6.0))
       )
     }
   }
@@ -607,7 +675,7 @@ class AggregationColumnsSpec
         "keyCol",
         variance(colDouble("col1")),
         f.variance(f.col("col1")),
-        List(None, Some(1.0))
+        List(Some(1.0), None)
       )
     }
 
@@ -623,7 +691,7 @@ class AggregationColumnsSpec
         "keyCol",
         varSamp(colDouble("col1")),
         f.var_samp(f.col("col1")),
-        List(None, Some(1.0))
+        List(Some(1.0), None)
       )
     }
   }
@@ -643,7 +711,7 @@ class AggregationColumnsSpec
         "keyCol",
         varPop(colDouble("col1")),
         f.var_pop(f.col("col1")),
-        List(Some(0.0), Some(0.6666666666666666))
+        List(Some(0.6666666666666666), Some(0.0))
       )
     }
   }

--- a/docs/docs/docs/exclusive.md
+++ b/docs/docs/docs/exclusive.md
@@ -15,8 +15,10 @@ import doric.AggExample.customMean
 ```
 
 ## Aggregations with doric syntax
+
 Doric introduces a simpler way to implement user defined aggregations, using doric's own syntax.
 The creation needs only five elements:
+
 - The column to make the aggregation
 - zero: the initialization of the value on each task.
 - Update: the function to update the accumulated value when processing a new column value.
@@ -27,20 +29,20 @@ The following example shows how to implement the average of a column of type int
 
 ```scala
       val customMean = customAgg[Long, Row, Double](
-        col[Long]("id"), // The column to work on
-        struct(lit(0L), lit(0L)), // setting the sum and the count to 0
-        (x, y) =>
-          struct(
-            x.getChild[Long]("col1") + y, // adding the value to the sum
-            x.getChild[Long]("col2") + 1L.lit // increasing in 1 the count of elemnts
-          ),
-        (x, y) =>
-          struct(
-            x.getChild[Long]("col1") + y.getChild[Long]("col1"), // obtaining the total sum of all 
-            x.getChild[Long]("col2") + y.getChild[Long]("col2") // obtaining the total count of all
-          ),
-        x => x.getChild[Long]("col1") / x.getChild[Long]("col2") // the total sum divided by the count
-      )
+  col[Long]("id"), // The column to work on
+  struct(lit(0L), lit(0L)), // setting the sum and the count to 0
+  (x, y) =>
+    struct(
+      x.getChild[Long]("col1") + y, // adding the value to the sum
+      x.getChild[Long]("col2") + 1L.lit // increasing in 1 the count of elemnts
+    ),
+  (x, y) =>
+    struct(
+      x.getChild[Long]("col1") + y.getChild[Long]("col1"), // obtaining the total sum of all 
+      x.getChild[Long]("col2") + y.getChild[Long]("col2") // obtaining the total count of all
+    ),
+  x => x.getChild[Long]("col1") / x.getChild[Long]("col2") // the total sum divided by the count
+)
 ```
 
 Now you can use your new aggregation as usual
@@ -51,3 +53,58 @@ spark.range(10).show()
 spark.range(10).select(customMean.as("customMean")).show()
 ```
 
+## Column mappings/matches
+
+Sometimes we must perform a mapping transformation based on a column value, so if its value is `key1` the output must
+be `result1`, if the value is `key2` the output must be `result2`, and so on.
+
+This is usually achieved by a `when` series using **spark**.
+
+```scala mdoc
+val dfMatch = Seq("key1", "key2", "key3", "anotherKey1", "anotherKey2").toDF()
+
+val mapColSpark = f.when(f.col("value") === "key1", "result1")
+  .when(f.col("value") === "key2", "result2") // actually we could write here a different column name, so the when will not work properly
+  .when(f.length(f.col("value")) > 4, "error key")
+  .otherwise(null)
+```
+
+We haven't reinvented the wheel, but now it is fail-proof (as we always match to the same column) and much simpler to
+map values using **doric**:
+
+```scala mdoc
+val mapColDoric = colString("value").matches[String]
+  // simple mappings, it is the same as if we use _ === "whatever"
+  .caseW("key1".lit, "result1".lit)
+  .caseW("key2".lit, "result2".lit)
+  // function equality
+  .caseW(_.length > 4, "error key".lit)
+  .otherwiseNull
+
+dfMatch.withColumn("mapResult", mapColDoric).show()
+```
+
+It is also a lot easier if you have a list of transformations, as we use the doric when builder under the hoods:
+```scala mdoc:silent
+val transformations = Map(
+  "key1" -> "result1",
+  "key2" -> "result2",
+  "key4" -> "result4"
+)
+
+// spark
+val sparkFold = transformations.tail.foldLeft(f.when(f.col("value") === transformations.head._1, transformations.head._2)) {
+  case (cases, (key, value)) =>
+    cases.when(f.col("value") === key, value)   // once again, what if I make a mistake and I write a different column?
+}
+  
+sparkFold.otherwise(null)
+
+// doric
+val doricFold = transformations.foldLeft(colString("value").matches[String]) {
+  case (cases, (key, value)) =>
+    cases.caseW(key.lit, value.lit)
+}
+  
+doricFold.otherwiseNull
+```


### PR DESCRIPTION
<!------------------------------------------------------------------->
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please, label your PR correctly as a fix, enhancement, etc.  -->
<!------------------------------------------------------------------->

## Description
<!-------------------------------------->
<!--- Describe your changes in detail -->
<!-------------------------------------->
* `AND` / `OR` aggregate functions were added (equivalent to `min` and `max` respectively, but seems more clear this way)
* `WhenBuilder` for columns, very similar to `WhenBuilder`, intended to do a sequence of comparisons with the column itself. It looks like this:
```
colInt("c1").matches[String]
    .caseW(_ > lit(10), "MAX".lit) // using a "compare" function
    .caseW(lit(8), "Eight".lit).   // this is direct comparison between both columns (the very same as ==)
    .otherwiseNull
```

## Related Issue and dependencies
<!---------------------------------------------------------------------------------------->
<!--- This project only accepts pull requests related to open issues                    -->
<!--- If suggesting a new feature or change, please discuss it in an issue first        -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce   -->
<!--- Write "Resolves #XXXX" in your comment to auto-close the issue that your PR fixes -->
<!--- Write "Depends on" or "Blocked by" in your comment to block your PR until the     -->
<!--       issue or PR is resolved                                                      -->
<!---------------------------------------------------------------------------------------->

* Resolves N/A
* Depends on N/A

## How Has This Been Tested?
<!---------------------------------------------------------------------------->
<!--- Please describe in detail how you tested your changes.                -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!---       see how your change affects other areas of the code, etc.       -->
<!---------------------------------------------------------------------------->
- This pull request contains appropriate tests?:
  - YES
