### PR TITLE
feat: [+] #337 array_sort of structs & equals null safe functions

### DIFF
--- a/core/src/main/scala/doric/CNameOrd.scala
+++ b/core/src/main/scala/doric/CNameOrd.scala
@@ -1,8 +1,12 @@
 package doric
 
 sealed trait Order
-object Asc  extends Order
-object Desc extends Order
+object Asc            extends Order
+object AscNullsFirst  extends Order
+object AscNullsLast   extends Order
+object Desc           extends Order
+object DescNullsFirst extends Order
+object DescNullsLast  extends Order
 
 case class CNameOrd(name: CName, order: Order)
 

--- a/core/src/main/scala/doric/CNameOrd.scala
+++ b/core/src/main/scala/doric/CNameOrd.scala
@@ -1,0 +1,18 @@
+package doric
+
+sealed trait Order
+object Asc  extends Order
+object Desc extends Order
+
+case class CNameOrd(name: CName, order: Order)
+
+object CNameOrd {
+  private final lazy val defaultOrder = Asc
+
+  def apply(name: String, order: Order): CNameOrd = this(CName(name), order)
+
+  def apply(name: String): CNameOrd = this(CName(name), defaultOrder)
+
+  implicit def colName2OrderedCol(colName: CName): CNameOrd =
+    CNameOrd(colName, defaultOrder)
+}

--- a/core/src/main/scala/doric/syntax/CommonColumns.scala
+++ b/core/src/main/scala/doric/syntax/CommonColumns.scala
@@ -127,6 +127,18 @@ private[syntax] trait CommonColumns extends ColGetters[NamedDoricColumn] {
       (column.elem, other.elem).mapN(_ === _).toDC
 
     /**
+      * Type & null safe equals between Columns
+      *
+      * @group All Types
+      * @param other
+      * the column to compare
+      * @return
+      * a reference to a Boolean DoricColumn with the comparation
+      */
+    def <=>(other: DoricColumn[T]): BooleanColumn =
+      (column.elem, other.elem).mapN(_ <=> _).toDC
+
+    /**
       * Type safe distinct between Columns
       * @group All Types
       * @param other

--- a/core/src/main/spark_3.0_3.1_3.2_3.3/scala/doric/syntax/ArrayColumns3x.scala
+++ b/core/src/main/spark_3.0_3.1_3.2_3.3/scala/doric/syntax/ArrayColumns3x.scala
@@ -125,6 +125,25 @@ trait ArrayColumns3x {
       private val arrRowCol: DoricColumn[F[Row]]
   ) {
 
+    /**
+      * Sorts the input array **of structs** based on the given column names and orders.
+      * It accepts also CName objects, which will be applied the default order
+      *
+      * @example {{{
+      * colArray[Row]("myColumn").sortBy(
+      *   // implicit conversion + default order
+      *   CName("column1"),
+      *
+      *   // default order
+      *   CNameOrd("column2"),
+      *
+      *   // Custom order
+      *   CNameOrd("column3", DescNullsLast)
+      * )
+      * }}}
+      *
+      * @group Array Type
+      */
     def sortBy(
         ordCol: CNameOrd,
         ordCols: CNameOrd*
@@ -132,32 +151,58 @@ trait ArrayColumns3x {
       val xv = x(arrRowCol.getIndex(0))
       val yv = y(arrRowCol.getIndex(1))
 
+      val << : Byte   = -1
+      val >> : Byte   = 1
+      val areEq: Byte = 0
+
       (arrRowCol.elem, xv.elem, yv.elem)
         .mapN((c, x, y) => {
 
           val getComparator: CNameOrd => Column = orderedCol => {
-            val comparator = new Column(
-              ArraySort.comparator(
-                x.getField(orderedCol.name.value).expr,
-                y.getField(orderedCol.name.value).expr
-              )
-            )
+            val left  = x.getField(orderedCol.name.value)
+            val right = y.getField(orderedCol.name.value)
+
+            val comparator: (Column, Column) => Column =
+              (l, r) => new Column(ArraySort.comparator(l.expr, r.expr))
+
+            def whenNullCond(
+                leftIsNull: Byte,
+                rightIsNull: Byte,
+                otherwise: Column
+            ): Column =
+              f.when(left.isNull and right.isNotNull, leftIsNull)
+                .when(left.isNotNull and right.isNull, rightIsNull)
+                .otherwise(otherwise)
 
             orderedCol.order match {
-              case Asc  => comparator // Default behaviour
-              case Desc => comparator * -1
+              case Asc | AscNullsLast =>
+                comparator(left, right) // Default behaviour
+              case AscNullsFirst =>
+                whenNullCond(
+                  leftIsNull = <<,
+                  rightIsNull = >>,
+                  otherwise = comparator(left, right)
+                )
+              case Desc | DescNullsFirst =>
+                comparator(right, left)
+              case DescNullsLast =>
+                whenNullCond(
+                  leftIsNull = >>,
+                  rightIsNull = <<,
+                  otherwise = comparator(right, left)
+                )
             }
           }
 
           val initialComparator = getComparator(ordCol)
-          val initial = f.when(initialComparator =!= 0, initialComparator)
+          val initial = f.when(initialComparator =!= areEq, initialComparator)
 
           val allColsComparator = ordCols
             .foldLeft(initial)((sortOpts, currCol) => {
               val comparator = getComparator(currCol)
-              sortOpts.when(comparator =!= 0, comparator)
+              sortOpts.when(comparator =!= areEq, comparator)
             })
-            .otherwise(0)
+            .otherwise(areEq)
 
           new Column(
             ArraySort(

--- a/core/src/test/scala/doric/DoricColumnSpec.scala
+++ b/core/src/test/scala/doric/DoricColumnSpec.scala
@@ -1,11 +1,11 @@
 package doric
 
 import doric.sem.{ColumnNotFound, DoricMultiError}
-import doric.syntax.User
+import doric.testUtilities.data.User
 import doric.types.SparkType
+
 import java.sql.{Date, Timestamp}
 import org.scalatest.EitherValues
-
 import org.apache.spark.sql.{Encoder, Row}
 
 class DoricColumnSpec extends DoricTestElements with EitherValues {

--- a/core/src/test/scala/doric/syntax/CommonColumnsSpec.scala
+++ b/core/src/test/scala/doric/syntax/CommonColumnsSpec.scala
@@ -87,6 +87,20 @@ class CommonColumnsSpec
       res shouldBe List(Some(true), Some(false), None, None, None)
     }
 
+    it("should be comparable as equals (null safe)") {
+      val df =
+        List(("1", "1"), ("2", "1"), (null, "2"), ("3", null), (null, null))
+          .toDF("col1", "col2")
+
+      val res = df
+        .select(colString("col1") <=> col("col2"))
+        .as[Option[Boolean]]
+        .collect()
+        .toList
+
+      res shouldBe List(true, false, false, false, true).map(Option(_))
+    }
+
     it("should be comparable as different") {
       val df =
         List(("1", "1"), ("2", "1"), (null, "2"), ("3", null), (null, null))

--- a/core/src/test/scala/doric/syntax/DStructOpsSpec.scala
+++ b/core/src/test/scala/doric/syntax/DStructOpsSpec.scala
@@ -2,12 +2,10 @@ package doric
 package syntax
 
 import doric.sem.{ChildColumnNotFound, ColumnTypeError, DoricMultiError}
+import doric.testUtilities.data.User
 import doric.types.SparkType
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType}
-
-case class User(name: String, surname: String, age: Int)
 
 class DStructOpsSpec extends DoricTestElements {
 

--- a/core/src/test/scala/doric/syntax/DynamicSpec.scala
+++ b/core/src/test/scala/doric/syntax/DynamicSpec.scala
@@ -1,9 +1,9 @@
 package doric
 package syntax
 
+import doric.testUtilities.data.User
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
-
 import org.apache.spark.sql.Row
 
 class DynamicSpec extends DoricTestElements with EitherValues with Matchers {

--- a/core/src/test/scala/doric/testUtilities/data/User.scala
+++ b/core/src/test/scala/doric/testUtilities/data/User.scala
@@ -1,0 +1,3 @@
+package doric.testUtilities.data
+
+case class User(name: String, surname: String, age: Int)

--- a/core/src/test/spark_3.0_3.1_3.2_3.3/scala/doric/syntax/ArrayColumns3xSpec.scala
+++ b/core/src/test/spark_3.0_3.1_3.2_3.3/scala/doric/syntax/ArrayColumns3xSpec.scala
@@ -232,7 +232,7 @@ class ArrayColumns3xSpec
           User("Batman", null, 30),
           User("Smeagol", null, 500)
         ),
-        List.empty,
+        Seq.empty,
         null
       ).toDF("col1")
 
@@ -281,7 +281,7 @@ class ArrayColumns3xSpec
           User(null, "Snow", 21),
           User(null, "Snow", 17)
         ),
-        List.empty,
+        Seq.empty,
         null
       )
 
@@ -293,6 +293,34 @@ class ArrayColumns3xSpec
           s"Expected: $expected"
       )
     }
+
+    lazy val input = Seq(
+      User("B", "", 0),
+      User(null, "", 0),
+      User("", "", 0),
+      User("A", "", 0)
+    )
+
+    def testOrder(order: Order, expected: Seq[String]): Unit = {
+
+      it(s"should order ${order.getClass.getSimpleName}") {
+        val df = Seq(input).toDF("value")
+
+        df.select(colArray[Row]("value").sortBy(CNameOrd("name", order)))
+          .as[List[User]]
+          .collect()
+          .toList
+          .head
+          .map(_.name) shouldBe expected
+      }
+    }
+
+    testOrder(Asc, Seq("", "A", "B", null))
+    testOrder(AscNullsLast, Seq("", "A", "B", null))
+    testOrder(AscNullsFirst, Seq(null, "", "A", "B"))
+    testOrder(Desc, Seq(null, "B", "A", ""))
+    testOrder(DescNullsLast, Seq("B", "A", "", null))
+    testOrder(DescNullsFirst, Seq(null, "B", "A", ""))
   }
 
 }

--- a/docs/docs/docs/exclusive.md
+++ b/docs/docs/docs/exclusive.md
@@ -1,10 +1,12 @@
 ---
 title: Doric Documentation
-permalink: docs/doric-exclusive-featues/
+permalink: docs/doric-exclusive-features/
 ---
 
+# Doric exclusive features
+
 ```scala mdoc:invisible
-import org.apache.spark.sql.{functions => f}
+import org.apache.spark.sql.{functions => f, Row}
 
 val spark = doric.DocInit.getSpark
 import spark.implicits._
@@ -32,7 +34,7 @@ The following example shows how to implement the average of a column of type int
         (x, y) =>
           struct(
             x.getChild[Long]("col1") + y, // adding the value to the sum
-            x.getChild[Long]("col2") + 1L.lit // increasing in 1 the count of elemnts
+            x.getChild[Long]("col2") + 1L.lit // increasing in 1 the count of elements
           ),
         (x, y) =>
           struct(
@@ -51,3 +53,42 @@ spark.range(10).show()
 spark.range(10).select(customMean.as("customMean")).show()
 ```
 
+## Custom sort for array columns & structured array columns
+Maybe you had to sort arrays more than a couple of times, not a big deal, but maybe you had to sort arrays of structs... Now it gets interesting.
+
+Currently, (spark 3.3.2 is the latest version) there is only one API function to sort arrays called `array_sort`, this will sort in descendant order any array type (in case of structs it will sort taking account the first column, then the second and so on). If you want to perform some custom order you have to write your own "spark function" or create an expression via SQL using which allows you to use the lambda function.
+
+Doric provides this function for earlier versions (since spark 3.0). In fact, doric provides a simplified functions in case you need to order a structured array column just providing the sub-column names instead of creating an ad-hoc order function
+
+```scala mdoc
+case class Character(name: String, description: String, age: Int)
+org.apache.spark.sql.catalyst.encoders.OuterScopes.addOuterScope(this)
+
+val dfArrayStruct = Seq(
+  Seq(
+    Character("Terminator", "T-800", 80),
+    Character("Yoda", null, 900),
+    Character("Gandalf", "white", 2),
+    Character("Terminator", "T-1000", 1),
+    Character("Gandalf", "grey", 2000)
+  )
+).toDF
+
+val sparkCol = f.expr("array_sort(value, (l, r) -> case " +
+  // name ASC
+  "when l.name < r.name then -1 " +
+  "when l.name > r.name then 1 " +
+  "else ( case" +
+  // age DESC
+  "  when l.age > r.age then -1 " +
+  "  when l.age < r.age then 1 " +
+  "  else 0 end " +
+  ") end)"
+)
+
+val doricCol = colArray[Row]("value").sortBy(CName("name"), CNameOrd("age", Desc))
+
+dfArrayStruct.select(sparkCol.as("sorted")).show(false)
+dfArrayStruct.select(doricCol.as("sorted")).show(false)
+
+```

--- a/docs/docs/docs/implicits.md
+++ b/docs/docs/docs/implicits.md
@@ -29,7 +29,7 @@ selecting arrays or maps, though: e.g., `colArray[Int]("name")` stands for `col[
 
 This is the whole list of column alias:
 
-| Doric column type |           Column alias            | 
+| Doric column type |            Column alias            | 
 |:-----------------:|:----------------------------------:|
 |     `String`      |             colString              |
 |      `Null`       |              colNull               |
@@ -205,4 +205,3 @@ colInt("int") + 1f //an integer with a float value can't be directly added in do
 ```scala mdoc:fail
 concat("hi", 5) // expects only strings and an integer is found
 ```
-


### PR DESCRIPTION
<!------------------------------------------------------------------->
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please, label your PR correctly as a fix, enhancement, etc.  -->
<!------------------------------------------------------------------->

## Description
<!-------------------------------------->
<!--- Describe your changes in detail -->
<!-------------------------------------->
This PR contains two new functions for doric:
* **Equals null safe**: `<=>`
* *Sort arrays for structs*: `colArray[Row]("value").sortBy(CName("name"), CNameOrd("age", Desc))` is available instead of createng ad-hoc sort functions or using ad-hoc expressions like:
```
f.expr("array_sort(value, (l, r) -> case " +
  // name ASC
  "when l.name < r.name then -1 " +
  "when l.name > r.name then 1 " +
  "else ( case" +
  // age DESC
  "  when l.age > r.age then -1 " +
  "  when l.age < r.age then 1 " +
  "  else 0 end " +
  ") end)"
)
```

## Related Issue and dependencies
<!---------------------------------------------------------------------------------------->
<!--- This project only accepts pull requests related to open issues                    -->
<!--- If suggesting a new feature or change, please discuss it in an issue first        -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce   -->
<!--- Write "Resolves #XXXX" in your comment to auto-close the issue that your PR fixes -->
<!--- Write "Depends on" or "Blocked by" in your comment to block your PR until the     -->
<!--       issue or PR is resolved                                                      -->
<!---------------------------------------------------------------------------------------->

* Resolves #337 
* Depends on N/A

## How Has This Been Tested?
<!---------------------------------------------------------------------------->
<!--- Please describe in detail how you tested your changes.                -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!---       see how your change affects other areas of the code, etc.       -->
<!---------------------------------------------------------------------------->
- This pull request contains appropriate tests?:
  - YES
