### PR TITLE
ISSUE-363: Add the ability to Drop columns with DoricColumns

### DIFF
--- a/core/src/main/scala/doric/sem/TransformOps.scala
+++ b/core/src/main/scala/doric/sem/TransformOps.scala
@@ -163,7 +163,8 @@ private[sem] trait TransformOps {
       */
     def drop(col: DoricColumn[_]*): DataFrame = {
       val dataFrame = df.toDF()
-      col.toList.traverse(_.elem)
+      col.toList
+        .traverse(_.elem)
         .run(dataFrame)
         .map(_.foldLeft(dataFrame)((df, col) => df.drop(col)))
         .returnOrThrow("drop")

--- a/core/src/main/scala/doric/sem/TransformOps.scala
+++ b/core/src/main/scala/doric/sem/TransformOps.scala
@@ -147,6 +147,7 @@ private[sem] trait TransformOps {
     /**
       * Drops specified column from the Dataframe.
       * @group Dataframe Transformation operation
+      * @note Unlike in Spark, dropping a column that does not exist will result in a ColumnNotFound exception
       */
     def drop(col: DoricColumn[_]): DataFrame = {
       col.elem
@@ -158,6 +159,7 @@ private[sem] trait TransformOps {
     /**
       * Drops specified columns from the Dataframe.
       * @group Dataframe Transformation operation
+      * @note Unlike in Spark, dropping columns that do not exist will result in a ColumnNotFound exception
       */
     def drop(col: DoricColumn[_]*): DataFrame = {
       val dataFrame = df.toDF()

--- a/core/src/test/scala/doric/sem/TransformOpsSpec.scala
+++ b/core/src/test/scala/doric/sem/TransformOpsSpec.scala
@@ -154,6 +154,18 @@ class TransformOpsSpec
       res shouldBe actual
     }
 
+    it("drop throws an error when column is not found") {
+      import spark.implicits._
+
+      val df = List(("a", "b")).toDF("col1", "col2")
+
+      intercept[DoricMultiError] {
+        df.drop(colString("invalid")).collect().toList
+      } should containAllErrors(
+        ColumnNotFound("invalid", List("col1", "col2"))
+      )
+    }
+
     it("drops multiple columns") {
       import spark.implicits._
 
@@ -163,6 +175,20 @@ class TransformOpsSpec
       val actual = List(Row("a"))
 
       res shouldBe actual
+    }
+
+    it("drop throws an error when columns are not found") {
+      import spark.implicits._
+
+      val df = List(("a", "b", 1, 2.0)).toDF("col1", "col2", "col3", "col4")
+
+      intercept[DoricMultiError] {
+        df.drop(colString("not"), colInt("a"), colDouble("column")).collect().toList
+      } should containAllErrors(
+        ColumnNotFound("not", List("col1", "col2", "col3", "col4")),
+        ColumnNotFound("a", List("col1", "col2", "col3", "col4")),
+        ColumnNotFound("column", List("col1", "col2", "col3", "col4")),
+      )
     }
   }
 }

--- a/core/src/test/scala/doric/sem/TransformOpsSpec.scala
+++ b/core/src/test/scala/doric/sem/TransformOpsSpec.scala
@@ -148,7 +148,7 @@ class TransformOpsSpec
 
       val df = List(("a", "b")).toDF("col1", "col2")
 
-      val res = df.drop(colString("col1")).collect().toList
+      val res    = df.drop(colString("col1")).collect().toList
       val actual = List(Row("b"))
 
       res shouldBe actual
@@ -171,7 +171,10 @@ class TransformOpsSpec
 
       val df = List(("a", "b", 1, 2.0)).toDF("col1", "col2", "col3", "col4")
 
-      val res = df.drop(colString("col2"), colInt("col3"), colDouble("col4")).collect().toList
+      val res = df
+        .drop(colString("col2"), colInt("col3"), colDouble("col4"))
+        .collect()
+        .toList
       val actual = List(Row("a"))
 
       res shouldBe actual
@@ -183,11 +186,13 @@ class TransformOpsSpec
       val df = List(("a", "b", 1, 2.0)).toDF("col1", "col2", "col3", "col4")
 
       intercept[DoricMultiError] {
-        df.drop(colString("not"), colInt("a"), colDouble("column")).collect().toList
+        df.drop(colString("not"), colInt("a"), colDouble("column"))
+          .collect()
+          .toList
       } should containAllErrors(
         ColumnNotFound("not", List("col1", "col2", "col3", "col4")),
         ColumnNotFound("a", List("col1", "col2", "col3", "col4")),
-        ColumnNotFound("column", List("col1", "col2", "col3", "col4")),
+        ColumnNotFound("column", List("col1", "col2", "col3", "col4"))
       )
     }
   }

--- a/core/src/test/scala/doric/sem/TransformOpsSpec.scala
+++ b/core/src/test/scala/doric/sem/TransformOpsSpec.scala
@@ -2,6 +2,7 @@ package doric
 package sem
 
 import doric.implicitConversions._
+import org.apache.spark.sql.Row
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.EitherValues
 
@@ -140,6 +141,28 @@ class TransformOpsSpec
         (10, 1),
         (11, 1)
       )
+    }
+
+    it("drops a single column") {
+      import spark.implicits._
+
+      val df = List(("a", "b")).toDF("col1", "col2")
+
+      val res = df.drop(colString("col1")).collect().toList
+      val actual = List(Row("b"))
+
+      res shouldBe actual
+    }
+
+    it("drops multiple columns") {
+      import spark.implicits._
+
+      val df = List(("a", "b", 1, 2.0)).toDF("col1", "col2", "col3", "col4")
+
+      val res = df.drop(colString("col2"), colInt("col3"), colDouble("col4")).collect().toList
+      val actual = List(Row("a"))
+
+      res shouldBe actual
     }
   }
 }


### PR DESCRIPTION
## Description
This PR updates `transform` ops to add the `drop` column found in Spark. The doric function has the following extra functionality:
- It will return an error if the column is not found in the DataFrame
- You can drop multiple columns using the `col` syntax

## Related Issue and dependencies
<!---------------------------------------------------------------------------------------->
<!--- This project only accepts pull requests related to open issues                    -->
<!--- If suggesting a new feature or change, please discuss it in an issue first        -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce   -->
<!--- Write "Resolves #XXXX" in your comment to auto-close the issue that your PR fixes -->
<!--- Write "Depends on" or "Blocked by" in your comment to block your PR until the     -->
<!--       issue or PR is resolved                                                      -->
<!---------------------------------------------------------------------------------------->

* Resolves [363](https://github.com/hablapps/doric/issues/363)

## How Has This Been Tested?
Unit tests have been updated to include testing of both `drop` functions.

- This pull request contains appropriate tests?:
  - YES