### PR TITLE
Update scala 2.13 to allow update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versionRegex      = """^(.*)\.(.*)\.(.*)$""".r
 val versionRegexShort = """^(.*)\.(.*)$""".r
 
 val scala212 = "2.12.18"
-val scala213 = "2.13.8"
+val scala213 = "2.13.12"
 
 val parserSparkVersion: String => String = {
   case versionRegexShort("3", "0") => spark30Version


### PR DESCRIPTION
## Description
Newer versions of scala test requires an updated version of scala 2.13

## Related Issue and dependencies
#427 
* Resolves #427 
* Depends on none

## How Has This Been Tested?
Pass the provided test test is enough.
- This pull request contains appropriate tests?:
  - YES
